### PR TITLE
Allow Mock to Throw exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,21 @@ A `MockMethod` represents a method to be mocked in a unit test. An instance of `
 ```java
 MockClass mockAccountsSelector = new MockClass();
 
-List<Account> accountsToReturnOnFirstInvocation = new List<Account>{ // specific accounts };
-List<Account> accountsToReturnOnSecondInvocation = new List<Account> { // other specific accounts }
+List<Account> accountsToReturnOnFirstInvocation = new List<Account>{ /* specific accounts */ };
+List<Account> accountsToReturnOnSecondInvocation = new List<Account> { /*  other specific accounts */ }
 List<Object> returnValues = new List<Object> { accountsToReturnOnFirstInvocation, accountsToReturnOnSecondInvocation };
+
+MockMethod mockSelectById = new MockMethod('selectById', returnValues);
+mockAccountsSelector.addMockMethod(mockSelectById);
+```
+*Defining exceptions: If you want to throw an exception when the method is called, you can define an exception as a return value. The exception should be an instance of `Exception`.*
+
+```java
+MockClass mockAccountsSelector = new MockClass();
+
+List<Account> accountsToReturnOnFirstInvocation = new List<Account>{ // specific accounts };
+MyCustomException customException = new MyCustomException('Throw me'); // Exception to throw second time method is called
+List<Object> returnValues = new List<Object> { accountsToReturnOnFirstInvocation, customException };
 
 MockMethod mockSelectById = new MockMethod('selectById', returnValues);
 mockAccountsSelector.addMockMethod(mockSelectById);

--- a/lib/src/MockMethod.cls
+++ b/lib/src/MockMethod.cls
@@ -50,7 +50,11 @@ public class MockMethod {
   public Object handleMethodCall(List<Object> parameters) {
     this.timesCalled += 1;
     this.callParameters.add(parameters);
-    return this.values.remove(0);
+    Object value = this.values.remove(0);
+    if (value instanceof Exception) {
+      throw (Exception) value;
+    }
+    return value;
   }
 
   /**

--- a/lib/test/MockMethodTest.cls
+++ b/lib/test/MockMethodTest.cls
@@ -74,4 +74,32 @@ private with sharing class MockMethodTest {
       thrownException.getMessage()
     );
   }
+
+  @IsTest
+  private static void handleMethodCall_throwsExceptoinWhenDefined() {
+    // given
+    MockMethodTestException testException = new MockMethodTestException('Test Exception');
+
+    MockMethod mockMethod = new MockMethod(
+      'method',
+      new List<Object>{ 'methodReturnValue', testException}
+    );
+
+    // when
+    String result = (String) mockMethod.handleMethodCall(
+      new List<Object>{ 'methodParameters' }
+    );
+
+    MockMethodTestException caughtException;
+    try {
+      mockMethod.handleMethodCall(new List<Object>{ 'methodParameters' });
+    } catch (MockMethodTestException e) {
+      caughtException = e;
+    }
+
+    // then
+    Assert.areEqual(testException, caughtException, 'Exception should be thrown');
+  }
+
+  private class MockMethodTestException extends Exception {}
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `MockMethod` class and updates the corresponding documentation and tests. The key changes include adding support for throwing exceptions when a method is called and updating the unit tests to cover this new functionality.

### Enhancements to `MockMethod` class:

* [`lib/src/MockMethod.cls`](diffhunk://#diff-36cbe124a8ef8cab562d34e993ed0ca5b6aeed6e8c0155cfc2b68ba4c3bf52ddL53-R57): Modified the `handleMethodCall` method to check if the value is an instance of `Exception` and throw it if true. (`[lib/src/MockMethod.clsL53-R57](diffhunk://#diff-36cbe124a8ef8cab562d34e993ed0ca5b6aeed6e8c0155cfc2b68ba4c3bf52ddL53-R57)`)

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R168): Updated the example to include defining exceptions as return values and how to use them in `MockMethod`. (`[README.mdL153-R168](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R168)`)

### Unit test updates:

* [`lib/test/MockMethodTest.cls`](diffhunk://#diff-a1321719b679328f003ebe22e4d83f69a0c61196aa3cf26c262faef36a3a232cR77-R104): Added a new test method `handleMethodCall_throwsExceptionWhenDefined` to verify that exceptions are correctly thrown when defined in the return values. (`[lib/test/MockMethodTest.clsR77-R104](diffhunk://#diff-a1321719b679328f003ebe22e4d83f69a0c61196aa3cf26c262faef36a3a232cR77-R104)`)